### PR TITLE
Sync with upstream v0.3.2 release

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,32 @@
+name: Ruby Gem
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: "zulu"
+      - name: push gem
+        uses: trocco-io/push-gem-to-gpr-action@v2
+        with:
+          language: java
+          gem-path: "./build/gems/*.gem"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id "maven"
     id 'maven-publish'
     id "org.embulk.embulk-plugins" version "0.4.2"
+    id "com.palantir.git-version" version "3.0.0"
 }
 
 repositories {
@@ -18,9 +19,16 @@ repositories {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-group = "com.treasuredata.embulk.plugins"
+group = "trocco-io"
+version = {
+    def vd = versionDetails()
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v?[0-9]+\.[0-9]+\.[0-9]+([.-][.a-zA-Z0-9-]+)?/) {
+        vd.lastTag.replaceFirst(/^v/, "")
+    } else {
+        "0.0.0.${vd.gitHash}"
+    }
+}()
 description = "An Embulk plugin to loads records from Azure Blob Storage."
-version = "0.3.2"
 
 def embulkVersion = '0.10.31';
 


### PR DESCRIPTION
This PR updates our fork to follow the latest upstream version (v0.3.2) of `embulk-input-azure_blob_storage`.